### PR TITLE
👷 ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+run-name: "Deploy to GitHub Pages by @${{ github.actor }}"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate GraphQL docs
+        run: npm run doc
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/dist

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/graphql-markdown/demo-vite-vocs/tree/main)
 
+**Live demo:** [graphql-markdown.dev/demo-vite-vocs](https://graphql-markdown.dev/demo-vite-vocs/)
+
 ## 🚀 Project Structure
 
 Inside your GraphQL-Markdown + [Vite](https://https://vite.dev/)/[Vocs](https://vocs.dev/) project, you'll see the following folders and files:

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -4,5 +4,6 @@ import path from 'node:path'
 
 export default defineConfig({
   title: 'Docs',
+  basePath: '/demo-vite-vocs',
   sidebar: generateSidebar(path.join(__dirname, 'docs/pages'))
 })


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` (`workflow_dispatch`, main-only)
- Installs Node.js 22, runs `npm ci`, `npm run doc` (generates GraphQL docs), then `npm run build`
- Deploys `./docs/dist` to `gh-pages` via `peaceiris/actions-gh-pages`
- Adds live demo link to README

## Setup required

**Settings → Pages → Source → Deploy from a branch → `gh-pages` / `/(root)`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)